### PR TITLE
refactor: Move user input trimming from gateway to authz service

### DIFF
--- a/microservices/the_monkeys_authz/internal/services/services.go
+++ b/microservices/the_monkeys_authz/internal/services/services.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/the-monkeys/the_monkeys/apis/serviceconn/gateway_authz/pb"
@@ -47,6 +48,8 @@ func (as *AuthzSvc) RegisterUser(ctx context.Context, req *pb.RegisterUserReques
 	as.logger.Debugf("got the request data for : %+v", req.Email)
 	user := &models.TheMonkeysUser{}
 
+	
+
 	if err := utils.ValidateRegisterUserRequest(req); err != nil {
 		as.logger.Errorf("incomplete request body provided for email %s, error: %+v", req.Email, err)
 		return nil, status.Errorf(codes.InvalidArgument, "Incomplete request body provided for email %s", req.Email)
@@ -68,9 +71,9 @@ func (as *AuthzSvc) RegisterUser(ctx context.Context, req *pb.RegisterUserReques
 	// Create a userId and username
 	user.AccountId = utils.GenerateGUID()
 	user.Username = utils.GenerateGUID()
-	user.FirstName = req.FirstName
-	user.LastName = req.GetLastName()
-	user.Email = req.GetEmail()
+	user.FirstName = strings.TrimSpace(req.FirstName)
+	user.LastName = strings.TrimSpace(req.LastName)
+	user.Email = strings.TrimSpace(req.Email)
 	user.Password = utils.HashPassword(req.Password)
 	user.UserStatus = "active"
 	user.EmailVerificationToken = encHash
@@ -738,9 +741,9 @@ func (as *AuthzSvc) GoogleLogin(ctx context.Context, req *pb.RegisterUserRequest
 	// Create a userId and username
 	user.AccountId = utils.GenerateGUID()
 	user.Username = utils.GenerateGUID()
-	user.FirstName = req.FirstName
-	user.LastName = req.GetLastName()
-	user.Email = req.GetEmail()
+	user.FirstName = strings.TrimSpace(req.FirstName)
+	user.LastName = strings.TrimSpace(req.LastName)
+	user.Email = strings.TrimSpace(req.Email)
 	user.Password = utils.HashPassword(req.Password)
 	user.UserStatus = "active"
 	user.EmailVerificationToken = encHash

--- a/microservices/the_monkeys_authz/internal/services/services.go
+++ b/microservices/the_monkeys_authz/internal/services/services.go
@@ -46,6 +46,11 @@ func NewAuthzSvc(dbCli db.AuthDBHandler, jwt utils.JwtWrapper, config *config.Co
 
 func (as *AuthzSvc) RegisterUser(ctx context.Context, req *pb.RegisterUserRequest) (*pb.RegisterUserResponse, error) {
 	as.logger.Debugf("got the request data for : %+v", req.Email)
+	// Cleanup request data
+	req.Email = strings.ToLower(strings.TrimSpace(req.Email))
+	req.FirstName = strings.TrimSpace(req.FirstName)
+	req.LastName = strings.TrimSpace(req.LastName)
+	req.IpAddress = strings.TrimSpace(req.IpAddress)
 	user := &models.TheMonkeysUser{}
 
 	
@@ -71,9 +76,9 @@ func (as *AuthzSvc) RegisterUser(ctx context.Context, req *pb.RegisterUserReques
 	// Create a userId and username
 	user.AccountId = utils.GenerateGUID()
 	user.Username = utils.GenerateGUID()
-	user.FirstName = strings.TrimSpace(req.FirstName)
-	user.LastName = strings.TrimSpace(req.LastName)
-	user.Email = strings.TrimSpace(req.Email)
+	user.FirstName = req.FirstName
+	user.LastName = req.GetLastName()
+	user.Email = req.GetEmail()
 	user.Password = utils.HashPassword(req.Password)
 	user.UserStatus = "active"
 	user.EmailVerificationToken = encHash
@@ -741,9 +746,9 @@ func (as *AuthzSvc) GoogleLogin(ctx context.Context, req *pb.RegisterUserRequest
 	// Create a userId and username
 	user.AccountId = utils.GenerateGUID()
 	user.Username = utils.GenerateGUID()
-	user.FirstName = strings.TrimSpace(req.FirstName)
-	user.LastName = strings.TrimSpace(req.LastName)
-	user.Email = strings.TrimSpace(req.Email)
+	user.FirstName = req.FirstName
+	user.LastName = req.GetLastName()
+	user.Email = req.GetEmail()
 	user.Password = utils.HashPassword(req.Password)
 	user.UserStatus = "active"
 	user.EmailVerificationToken = encHash

--- a/microservices/the_monkeys_gateway/internal/auth/routes.go
+++ b/microservices/the_monkeys_gateway/internal/auth/routes.go
@@ -100,10 +100,6 @@ func (asc *ServiceClient) Register(ctx *gin.Context) {
 		return
 	}
 
-	body.FirstName = strings.TrimSpace(body.FirstName)
-	body.LastName = strings.TrimSpace(body.LastName)
-	body.Email = strings.TrimSpace(body.Email)
-
 	// check for google login
 	var loginMethod pb.RegisterUserRequest_LoginMethod
 	switch body.LoginMethod {


### PR DESCRIPTION
##  Description
Refactored user input sanitization to move `strings.TrimSpace()` logic from the gateway layer to the authz service layer for better separation of concerns.

## Changes Made
- Removed `strings.TrimSpace()` calls for `first_name`, `last_name`, and `email` from gateway layer (`routes.go`)
- Added `strings.TrimSpace()` calls in authz service (`services.go`):
  - `RegisterUser()` method 
  - `GoogleLogin()` method