### PR TITLE
Fix Elastic search sort error by replacing unmapped blog.time field with published_time

### DIFF
--- a/microservices/the_monkeys_blog/internal/database/blogs_matadata.go
+++ b/microservices/the_monkeys_blog/internal/database/blogs_matadata.go
@@ -60,8 +60,9 @@ func (es *elasticsearchStorage) GetBlogsMetadataByTags(ctx context.Context, tags
 	query := map[string]interface{}{
 		"sort": []map[string]interface{}{
 			{
-				"blog.time": map[string]string{
-					"order": "desc",
+				"published_time": map[string]interface{}{
+					"order":         "desc",
+					"unmapped_type": "date",
 				},
 			},
 		},
@@ -229,18 +230,13 @@ func (es *elasticsearchStorage) GetBlogsMetadataByTags(ctx context.Context, tags
 }
 
 func (es *elasticsearchStorage) GetAllPublishedBlogsMetadata(ctx context.Context, limit, offset int) ([]map[string]interface{}, int, error) {
-	// Build the query to get all published blogs with sorting by published_time or blog.time as fallback
+	// Build the query to get all published blogs sorted by published_time
 	query := map[string]interface{}{
 		"sort": []map[string]interface{}{
 			{
 				"published_time": map[string]interface{}{
 					"order":         "desc",
 					"unmapped_type": "date", // Handle cases where published_time is missing
-				},
-			},
-			{
-				"blog.time": map[string]string{
-					"order": "desc",
 				},
 			},
 		},
@@ -399,11 +395,6 @@ func (es *elasticsearchStorage) GetBlogsMetadataByQuery(ctx context.Context, que
 				"published_time": map[string]interface{}{
 					"order":         "desc",
 					"unmapped_type": "date",
-				},
-			},
-			{
-				"blog.time": map[string]string{
-					"order": "desc",
 				},
 			},
 		},
@@ -676,8 +667,9 @@ func (es *elasticsearchStorage) GetBlogsMetaByAccountId(ctx context.Context, acc
 		})
 	} else if isDraft {
 		sort = append(sort, map[string]interface{}{
-			"blog.time": map[string]string{
-				"order": "desc",
+			"published_time": map[string]interface{}{
+				"order":         "desc",
+				"unmapped_type": "date",
 			},
 		})
 	} else {
@@ -686,11 +678,6 @@ func (es *elasticsearchStorage) GetBlogsMetaByAccountId(ctx context.Context, acc
 				"published_time": map[string]interface{}{
 					"order":         "desc",
 					"unmapped_type": "date",
-				},
-			},
-			map[string]interface{}{
-				"blog.time": map[string]string{
-					"order": "desc",
 				},
 			},
 		)
@@ -874,11 +861,6 @@ func (es *elasticsearchStorage) GetBlogsMetaByBlogIdsV2(ctx context.Context, blo
 				"published_time": map[string]interface{}{
 					"order":         "desc",
 					"unmapped_type": "date", // Handle cases where published_time is missing
-				},
-			},
-			{
-				"blog.time": map[string]string{
-					"order": "desc",
 				},
 			},
 		},

--- a/microservices/the_monkeys_blog/internal/database/opensearch.go
+++ b/microservices/the_monkeys_blog/internal/database/opensearch.go
@@ -141,12 +141,13 @@ func (es *elasticsearchStorage) GetDraftBlogsByOwnerAccountID(ctx context.Contex
 		return nil, fmt.Errorf("ownerAccountID cannot be empty")
 	}
 
-	// Build the query to search for draft blogs by owner_account_id, sorted by time in descending order
+	// Build the query to search for draft blogs by owner_account_id, sorted by published_time in descending order
 	query := map[string]interface{}{
 		"sort": []map[string]interface{}{
 			{
-				"blog.time": map[string]string{
-					"order": "desc",
+				"published_time": map[string]interface{}{
+					"order":         "desc",
+					"unmapped_type": "date",
 				},
 			},
 		},
@@ -253,12 +254,13 @@ func (es *elasticsearchStorage) GetPublishedBlogsByOwnerAccountID(ctx context.Co
 		return nil, fmt.Errorf("ownerAccountID cannot be empty")
 	}
 
-	// Build the query to search for published blogs by owner_account_id, sorted by time in descending order
+	// Build the query to search for published blogs by owner_account_id, sorted by published_time in descending order
 	query := map[string]interface{}{
 		"sort": []map[string]interface{}{
 			{
-				"blog.time": map[string]string{
-					"order": "desc",
+				"published_time": map[string]interface{}{
+					"order":         "desc",
+					"unmapped_type": "date",
 				},
 			},
 		},
@@ -395,8 +397,9 @@ func (es *elasticsearchStorage) GetScheduledBlogsByOwnerAccountID(ctx context.Co
 	query := map[string]interface{}{
 		"sort": []map[string]interface{}{
 			{
-				"blog.time": map[string]string{
-					"order": "desc",
+				"schedule_time": map[string]interface{}{
+					"order":         "asc",
+					"unmapped_type": "date",
 				},
 			},
 		},
@@ -1047,8 +1050,9 @@ func (es *elasticsearchStorage) GetPublishedBlogByTagsName(ctx context.Context, 
 	query := map[string]interface{}{
 		"sort": []map[string]interface{}{
 			{
-				"blog.time": map[string]string{
-					"order": "desc",
+				"published_time": map[string]interface{}{
+					"order":         "desc",
+					"unmapped_type": "date",
 				},
 			},
 		},
@@ -1383,12 +1387,13 @@ func (es *elasticsearchStorage) DeleteABlogById(ctx context.Context, blogId stri
 
 // GetLast100BlogsLatestFirst retrieves the last 100 blogs sorted by the latest first
 func (es *elasticsearchStorage) GetLast100BlogsLatestFirst(ctx context.Context) (*pb.GetBlogsByTagsNameRes, error) {
-	// Build the query to retrieve the last 100 blogs, sorted by the time field in descending order
+	// Build the query to retrieve the last 100 blogs, sorted by published_time in descending order
 	query := map[string]interface{}{
 		"sort": []map[string]interface{}{
 			{
-				"blog.time": map[string]string{
-					"order": "desc",
+				"published_time": map[string]interface{}{
+					"order":         "desc",
+					"unmapped_type": "date",
 				},
 			},
 		},
@@ -1775,7 +1780,7 @@ func (es *elasticsearchStorage) GetBlogsByBlogIds(ctx context.Context, blogIds [
 		return nil, fmt.Errorf("blogIds array cannot be empty")
 	}
 
-	// Build the query to search for blogs by blog_id and sort by blog time in descending order (latest first)
+	// Build the query to search for blogs by blog_id and sort by published_time in descending order (latest first)
 	query := map[string]interface{}{
 		"query": map[string]interface{}{
 			"terms": map[string]interface{}{
@@ -1784,8 +1789,9 @@ func (es *elasticsearchStorage) GetBlogsByBlogIds(ctx context.Context, blogIds [
 		},
 		"sort": []map[string]interface{}{
 			{
-				"blog.time": map[string]string{
-					"order": "desc",
+				"published_time": map[string]interface{}{
+					"order":         "desc",
+					"unmapped_type": "date",
 				},
 			},
 		},

--- a/microservices/the_monkeys_blog/internal/database/v2_queries.go
+++ b/microservices/the_monkeys_blog/internal/database/v2_queries.go
@@ -61,12 +61,6 @@ func (es *elasticsearchStorage) GetBlogsOfUsersByAccountIds(ctx context.Context,
 					"unmapped_type": "date", // Use this to handle missing fields
 				},
 			},
-			{
-				"blog.time": map[string]interface{}{
-					"order":         "desc",
-					"unmapped_type": "long", // Use this as a fallback
-				},
-			},
 		},
 		"from": offset,
 		"size": limit,
@@ -186,8 +180,9 @@ func (es *elasticsearchStorage) GetBlogsByTagsAccId(ctx context.Context, account
 	query := map[string]interface{}{
 		"sort": []map[string]interface{}{
 			{
-				"blog.time": map[string]string{
-					"order": "desc",
+				"published_time": map[string]interface{}{
+					"order":         "desc",
+					"unmapped_type": "date",
 				},
 			},
 		},
@@ -318,8 +313,9 @@ func (es *elasticsearchStorage) GetBlogsByAccountId(ctx context.Context, account
 	query := map[string]interface{}{
 		"sort": []map[string]interface{}{
 			{
-				"blog.time": map[string]string{
-					"order": "desc",
+				"published_time": map[string]interface{}{
+					"order":         "desc",
+					"unmapped_type": "date",
 				},
 			},
 		},
@@ -645,8 +641,9 @@ func (es *elasticsearchStorage) GetBlogsByTags(ctx context.Context, tags []strin
 	query := map[string]interface{}{
 		"sort": []map[string]interface{}{
 			{
-				"blog.time": map[string]string{
-					"order": "desc",
+				"published_time": map[string]interface{}{
+					"order":         "desc",
+					"unmapped_type": "date",
 				},
 			},
 		},
@@ -772,8 +769,9 @@ func (es *elasticsearchStorage) GetBlogsByBlogIdsV2(ctx context.Context, blogIds
 	query := map[string]interface{}{
 		"sort": []map[string]interface{}{
 			{
-				"blog.time": map[string]string{
-					"order": "desc",
+				"published_time": map[string]interface{}{
+					"order":         "desc",
+					"unmapped_type": "date",
 				},
 			},
 		},
@@ -870,18 +868,13 @@ func (es *elasticsearchStorage) GetBlogsByBlogIdsV2(ctx context.Context, blogIds
 }
 
 func (es *elasticsearchStorage) GetAllPublishedBlogsLatestFirst(ctx context.Context, limit, offset int) ([]map[string]interface{}, error) {
-	// Build the query to get all published blogs with sorting by published_time or blog.time as fallback
+	// Build the query to get all published blogs sorted by published_time
 	query := map[string]interface{}{
 		"sort": []map[string]interface{}{
 			{
 				"published_time": map[string]interface{}{
 					"order":         "desc",
 					"unmapped_type": "date", // Handle cases where published_time is missing
-				},
-			},
-			{
-				"blog.time": map[string]string{
-					"order": "desc",
 				},
 			},
 		},


### PR DESCRIPTION
### Problem:
The blog service was failing with an Elasticsearch query error: "No mapping found for [blog.time] in order to sort on". This occurred because the [blog.time](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) field was referenced in sort clauses across multiple query functions, but it doesn't exist in the actual index mapping. The live index uses published_time (a date field) for sorting published blogs, and schedule_time for scheduled blogs.

### Solution:
Replaced all invalid [blog.time](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) sort references in the following files with appropriate mapped fields:

`blogs_matadata.go`
`opensearch.go`
`v2_queries.go`

Changes include:

- Using published_time with unmapped_type: "date" for descending sorts on published/draft blogs.
- Using schedule_time with unmapped_type: "date" for ascending sorts on scheduled blogs.
- Removed obsolete `blog.time` fallback clauses.
- Updated comments to reflect the actual persisted fields.

Validation:

- Code compiles successfully with go test.
- No more `blog.time` references in the database package.
- Queries now sort on existing mapped fields, preventing the 400 Bad Request error.
- This ensures reliable blog metadata retrieval and resolves the streaming error in the API endpoint `/api/v2/blog/user/{accountId}`.