### PR TITLE
Fix username update error handling and add strict validation

### DIFF
--- a/microservices/the_monkeys_authz/internal/services/services.go
+++ b/microservices/the_monkeys_authz/internal/services/services.go
@@ -1037,6 +1037,11 @@ func (as *AuthzSvc) UpdateUsername(ctx context.Context, req *pb.UpdateUsernameRe
 		return nil, status.Errorf(codes.InvalidArgument, "current username or new username cannot be empty")
 	}
 
+	// Allow only letters, numbers, underscore and period in usernames.
+	if !utils.IsValidUsername(req.NewUsername) {
+		return nil, status.Errorf(codes.InvalidArgument, "Usernames can only contain letters, numbers, underscores, and periods.")
+	}
+
 	if utils.IsRestrictedUsername(req.NewUsername) {
 		return nil, status.Errorf(codes.InvalidArgument, "the username %s is not allowed, please choose a different username", req.NewUsername)
 	}
@@ -1049,6 +1054,16 @@ func (as *AuthzSvc) UpdateUsername(ctx context.Context, req *pb.UpdateUsernameRe
 			return nil, status.Errorf(codes.NotFound, "user %s doesn't exist", req.CurrentUsername)
 		}
 		return nil, status.Errorf(codes.Internal, "cannot get the user profile")
+	}
+
+	// Ensure the new username isn't already taken by another user.
+	// Without this pre-check the UPDATE below hits the unique constraint and
+	// surfaces as a generic Internal error (HTTP 500) instead of a clear conflict.
+	if _, err := as.dbConn.CheckIfUsernameExist(req.NewUsername); err == nil {
+		return nil, status.Errorf(codes.AlreadyExists, "the username %s is already taken", req.NewUsername)
+	} else if err != sql.ErrNoRows {
+		as.logger.Errorf("error while checking availability of new username %s, err: %v", req.NewUsername, err)
+		return nil, status.Errorf(codes.Internal, "cannot verify username availability")
 	}
 
 	// Update the username

--- a/microservices/the_monkeys_authz/internal/utils/utils.go
+++ b/microservices/the_monkeys_authz/internal/utils/utils.go
@@ -126,6 +126,15 @@ func IsRestrictedUsername(username string) bool {
 	return false
 }
 
+// usernameRegex allows only letters, digits, underscore and period.
+var usernameRegex = regexp.MustCompile(`^[a-zA-Z0-9_.]+$`)
+
+// IsValidUsername reports whether the username uses only allowed characters
+// [a-zA-Z0-9_.]. Only checked on write, so existing usernames still work.
+func IsValidUsername(username string) bool {
+	return usernameRegex.MatchString(username)
+}
+
 // Function to shuffle a string
 //func shuffleString(s string) string {
 //	// Convert string to a slice of runes (to handle Unicode characters properly)

--- a/microservices/the_monkeys_gateway/internal/auth/routes.go
+++ b/microservices/the_monkeys_gateway/internal/auth/routes.go
@@ -741,6 +741,12 @@ func (asc *ServiceClient) UpdateUserName(ctx *gin.Context) {
 		if status.Code(err) == codes.NotFound {
 			ctx.AbortWithStatusJSON(http.StatusNotFound, gin.H{"message": "user not found"})
 			return
+		} else if status.Code(err) == codes.AlreadyExists {
+			ctx.AbortWithStatusJSON(http.StatusConflict, gin.H{"message": "Username is already taken. Please try another."})
+			return
+		} else if status.Code(err) == codes.InvalidArgument {
+			ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"message": status.Convert(err).Message()})
+			return
 		} else {
 			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": "couldn't update username"})
 			return


### PR DESCRIPTION
Return 409 when the new username is already taken and 400 for invalid input, and restrict usernames to letters, numbers, underscore and period (monkeys_brain #385, #386).